### PR TITLE
Reference USB-devices by vendor/product-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ grub> terminal_input usb_gamepad
 
 ```console
 $ lsusb
-$ sudo qemu-system-i386 -usb -device usb-host,vendorid=<gamepad-vendorid>,productid=<gamepad-productid> -cdrom test.iso
+$ sudo qemu-system-i386 -usb -device usb-host,hostbus=<gamepad-bus>,hostaddr=<gamepad-addr> -cdrom test.iso # Alternatively, you can reference your device by its ids -device usb-host,vendorid=<gamepad-vendorid>,productid=<gamepad-productid> 
 grub> nativedisk pata
 grub> nativedisk uhci
 grub> insmod usb_gamepad
 grub> terminal_input usb_gamepad
 ```
+
+
+
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ grub> terminal_input usb_gamepad
 
 ```console
 $ lsusb
-$ sudo qemu-system-i386 -usb -device usb-host,hostbus=<gamepad-bus>,hostaddr=<gamepad-addr> -cdrom test.iso
+$ sudo qemu-system-i386 -usb -device usb-host,vendorid=<gamepad-vendorid>,productid=<gamepad-productid> -cdrom test.iso
 grub> nativedisk pata
 grub> nativedisk uhci
 grub> insmod usb_gamepad

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ grub> insmod usb_gamepad
 grub> terminal_input usb_gamepad
 ```
 
-
-
-
 ## Architecture
 
 ### Adding New Module


### PR DESCRIPTION
Switched qemu launch command example from bus/address to vendorid/productid in order to avoid problems when the test device gets assigned another bus address